### PR TITLE
Add Verbose Option To Enable Command Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and [pre_commit_hook](https://hex.pm/packages/pre_commit_hook) for Elixir.
 
 
 We wanted something which was configurable with your own mix commands and
-just in elixir, so we created our own module.
+just in Elixir, so we created our own module.
 
 The first step will be to add this module to your mix.exs.
 ```elixir
@@ -24,6 +24,14 @@ In your config file you will have to add in this line:
 ```
 You can add any mix commands to the list, and these will run on commit,
 stopping the commit if they fail, or allowing the commit if they all pass.
+
+You can also have pre-commit display the output of the commands you run by
+setting the :verbose option.
+```
+  config :pre_commit,
+    commands: ["test"],
+    verbose: true
+```
 
 You will have to compile your app before committing in order for the pre-commit to work.
 

--- a/lib/mix/tasks/pre_commit.ex
+++ b/lib/mix/tasks/pre_commit.ex
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.PreCommit do
     and print the error message to the terminal.
   """
   @commands Application.get_env(:pre_commit, :commands) || []
+  @verbose Application.get_env(:pre_commit, :verbose) || false
 
 
   def run(_) do
@@ -24,7 +25,12 @@ defmodule Mix.Tasks.PreCommit do
 
 
   defp run_cmds(cmd) do
-    System.cmd("mix", String.split(cmd, " "), stderr_to_stdout: true)
+    into = case @verbose do
+      true -> IO.stream(:stdio, :line)
+      _    -> ""
+    end
+
+    System.cmd("mix", String.split(cmd, " "), stderr_to_stdout: true, into: into)
     |> case do
       {_result, 0} ->
         IO.puts "mix #{cmd} ran successfully."

--- a/lib/mix/tasks/pre_commit.ex
+++ b/lib/mix/tasks/pre_commit.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.PreCommit do
       {_result, 0} ->
         IO.puts "mix #{cmd} ran successfully."
       {result, _} ->
-        IO.puts result
+        if !@verbose, do: IO.puts result
         IO.puts "\e[31mPre-commit failed on `mix #{cmd}`.\e[0m \nCommit again with --no-verify to live dangerously and skip pre-commit."
         System.halt(1)
     end

--- a/lib/pre_commit.ex
+++ b/lib/pre_commit.ex
@@ -24,6 +24,14 @@ defmodule PreCommit do
   You can add any mix commands to the list, and these will run on commit,
   stopping the commit if they fail, or allowing the commit if they all pass.
 
+  You can also have pre-commit display the output of the commands you run by
+  setting the :verbose option.
+  ```
+  config :pre_commit,
+  commands: ["test"],
+  verbose: true
+  ```
+
   You will have to compile your app before committing in order for the pre-commit to work.
 
   As a note, this module will only work with scripts which exit with a code of


### PR DESCRIPTION
This PR adds a new config item (`:verbose`) to enable displaying the output of commands run during pre-commit. I've added this to allow for a more transparent experience when the pre-commit step involves running large or long-running tasks.

Fix #19 